### PR TITLE
FIX issue with composed HOC and forwarded ref

### DIFF
--- a/src/lib/handleViewport.js
+++ b/src/lib/handleViewport.js
@@ -1,29 +1,28 @@
 // HOC for handleViewport
 import React, { useRef, forwardRef } from 'react';
-import hoistNonReactStatic from 'hoist-non-react-statics';
 import useInViewport from './useInViewport';
 
 const noop = () => {};
 
 function handleViewport(TargetComponent, options, config = { disconnectOnLeave: false }) {
-  const ForwardedRefComponent = forwardRef((props, ref) => {
-    return <TargetComponent {...props} forwardedRef={ref} />;
-  });
-
-  const InViewport = ({ onEnterViewport = noop, onLeaveViewport = noop, ...restProps }) => {
-    const node = useRef();
+  const InViewport = ({
+    onEnterViewport = noop,
+    onLeaveViewport = noop,
+    ...restProps
+  }, ref) => {
+    const node = useRef(ref);
     const { inViewport, enterCount, leaveCount } = useInViewport(
       node,
       options,
       config,
       {
         onEnterViewport,
-        onLeaveViewport
-      }
+        onLeaveViewport,
+      },
     );
-
+    
     return (
-      <ForwardedRefComponent
+      <TargetComponent
         {...restProps}
         inViewport={inViewport}
         enterCount={enterCount}
@@ -33,7 +32,9 @@ function handleViewport(TargetComponent, options, config = { disconnectOnLeave: 
     );
   };
 
-  return hoistNonReactStatic(InViewport, ForwardedRefComponent);
+  const name = TargetComponent.displayName || TargetComponent.name || 'Component';
+  InViewport.displayName = `handleViewport(${name})`;
+  return forwardRef(InViewport);
 }
 
 export default handleViewport;

--- a/src/lib/handleViewport.js
+++ b/src/lib/handleViewport.js
@@ -17,8 +17,8 @@ function handleViewport(TargetComponent, options, config = { disconnectOnLeave: 
       config,
       {
         onEnterViewport,
-        onLeaveViewport,
-      },
+        onLeaveViewport
+      }
     );
     
     return (


### PR DESCRIPTION
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

```
Check the render method of `RouterAndRefHoc`.
    in InViewport (created by RouterAndRefHoc)
```